### PR TITLE
Display all Historian columns

### DIFF
--- a/INX_WorkChecking/_idb/HistorianLive.aspx
+++ b/INX_WorkChecking/_idb/HistorianLive.aspx
@@ -23,7 +23,21 @@
                         <asp:BoundField DataField="DateTime" HeaderText="資料時間" DataFormatString="{0:yyyy-MM-dd HH:mm:ss}" ItemStyle-HorizontalAlign="Center" />
                         <asp:BoundField DataField="TagName" HeaderText="TagName" />
                         <asp:BoundField DataField="Value" HeaderText="Value" ItemStyle-HorizontalAlign="Right" />
+                        <asp:BoundField DataField="vValue" HeaderText="vValue" />
                         <asp:BoundField DataField="Quality" HeaderText="Quality" ItemStyle-HorizontalAlign="Center" />
+                        <asp:BoundField DataField="QualityDetail" HeaderText="QualityDetail" ItemStyle-HorizontalAlign="Center" />
+                        <asp:BoundField DataField="OPCQuality" HeaderText="OPCQuality" ItemStyle-HorizontalAlign="Center" />
+                        <asp:BoundField DataField="wwTagKey" HeaderText="wwTagKey" ItemStyle-HorizontalAlign="Center" />
+                        <asp:BoundField DataField="wwRetrievalMode" HeaderText="wwRetrievalMode" />
+                        <asp:BoundField DataField="wwTimeDeadband" HeaderText="wwTimeDeadband" ItemStyle-HorizontalAlign="Center" />
+                        <asp:BoundField DataField="wwValueDeadband" HeaderText="wwValueDeadband" ItemStyle-HorizontalAlign="Right" />
+                        <asp:BoundField DataField="wwTimeZone" HeaderText="wwTimeZone" />
+                        <asp:BoundField DataField="wwParameters" HeaderText="wwParameters" />
+                        <asp:BoundField DataField="SourceTag" HeaderText="SourceTag" />
+                        <asp:BoundField DataField="SourceServer" HeaderText="SourceServer" />
+                        <asp:BoundField DataField="wwValueSelector" HeaderText="wwValueSelector" />
+                        <asp:BoundField DataField="wwExpression" HeaderText="wwExpression" />
+                        <asp:BoundField DataField="wwUnit" HeaderText="wwUnit" />
                     </Columns>
                     <EmptyDataTemplate>
                         <div class="NoData">查無符合條件資料</div>

--- a/INX_WorkChecking/_idb/HistorianLive.aspx.cs
+++ b/INX_WorkChecking/_idb/HistorianLive.aspx.cs
@@ -27,7 +27,7 @@ namespace WebApp._idb
         {
             if (string.IsNullOrEmpty(ddlFactory.SelectedValue)) return null;
             string table = ddlFactory.SelectedValue.Replace("FAB", "FAC") + "_Historian_Live";
-            bPara.Command = $@"select [DateTime],[TagName],[Value],[Quality] from FAC_Loader.dbo.[{table}] where 1=1
+            bPara.Command = $@"select [DateTime],[TagName],[Value],[vValue],[Quality],[QualityDetail],[OPCQuality],[wwTagKey],[wwRetrievalMode],[wwTimeDeadband],[wwValueDeadband],[wwTimeZone],[wwParameters],[SourceTag],[SourceServer],[wwValueSelector],[wwExpression],[wwUnit] from FAC_Loader.dbo.[{table}] where 1=1
 {(string.IsNullOrWhiteSpace(txtTagName.Text) ? string.Empty : " and TagName like @Tag")}
 {(string.IsNullOrWhiteSpace(txtQuality.Text) ? string.Empty : " and Quality=@Quality")}";
             var param = new { Tag = $"%{txtTagName.Text.Trim()}%", Quality = txtQuality.Text };


### PR DESCRIPTION
## Summary
- update HistorianLive grid to show every column
- query all columns in HistorianLive backend

## Testing
- `dotnet build INX_Central_Web.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bae6cf5048333bfeee65ea2994cdf